### PR TITLE
Added minVersion tag to the mixin file

### DIFF
--- a/common/src/main/resources/rottencreatures-common.mixins.json
+++ b/common/src/main/resources/rottencreatures-common.mixins.json
@@ -1,5 +1,6 @@
 {
   "required": true,
+  "minVersion": "0.8",
   "package": "com.github.teamfusion.rottencreatures.mixin",
   "compatibilityLevel": "JAVA_17",
   "client": [

--- a/fabric/src/main/resources/rottencreatures.mixins.json
+++ b/fabric/src/main/resources/rottencreatures.mixins.json
@@ -1,5 +1,6 @@
 {
   "required": true,
+  "minVersion": "0.8",
   "package": "com.github.teamfusion.rottencreatures.mixin.fabric",
   "compatibilityLevel": "JAVA_17",
   "client": [

--- a/forge/src/main/resources/rottencreatures.mixins.json
+++ b/forge/src/main/resources/rottencreatures.mixins.json
@@ -1,5 +1,6 @@
 {
   "required": true,
+  "minVersion": "0.8",
   "package": "com.github.teamfusion.rottencreatures.mixin.forge",
   "compatibilityLevel": "JAVA_17",
   "client": [


### PR DESCRIPTION
I added this tag so the `[main/ERROR] [mixin/]: Mixin config rottencreatures-common.mixins.json does not specify "minVersion" property
[main/ERROR] [mixin/]: Mixin config rottencreatures.mixins.json does not specify "minVersion" property` error isn't showing up on every startup any longer. You can tweak the minVersion to your liking. 