### PR TITLE
Change IMMORTAL_CHANCE config type to Double

### DIFF
--- a/common/src/main/java/com/github/teamfusion/rottencreatures/ConfigEntries.java
+++ b/common/src/main/java/com/github/teamfusion/rottencreatures/ConfigEntries.java
@@ -11,5 +11,5 @@ public class ConfigEntries {
     public static final Config.Entry<Integer> UNDEAD_MINER_DEPTH = Config.create("Undead Miner Depth", 63, "determines the max y height where Undead Miners can spawn");
     public static final Config.Entry<Integer> MUMMY_WEIGHT = Config.create("Mummy Weight", 20, "determines how often will Mummies spawn");
     public static final Config.Entry<Integer> DEAD_BEARD_WEIGHT = Config.create("Dead Beard Weight", 1, "determines how often will Dead Beard spawn");
-    public static final Config.Entry<Float> IMMORTAL_CHANCE = Config.create("Immortal Chance", 0.025F, "determines the chance of spawning for Immortals");
+    public static final Config.Entry<Double> IMMORTAL_CHANCE = Config.create("Immortal Chance", 0.025D, "determines the chance of spawning for Immortals");
 }

--- a/common/src/main/java/com/github/teamfusion/rottencreatures/mixin/common/ServerLevelMixin.java
+++ b/common/src/main/java/com/github/teamfusion/rottencreatures/mixin/common/ServerLevelMixin.java
@@ -39,7 +39,7 @@ public abstract class ServerLevelMixin {
             BlockPos pos = this.findLightningTargetAround($this.getBlockRandomPos(x, 0, z, 15));
             if ($this.isRainingAt(pos)) {
                 DifficultyInstance difficulty = $this.getCurrentDifficultyAt(pos);
-                boolean canSpawn = $this.getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING) && $this.random.nextDouble() < (double)difficulty.getEffectiveDifficulty() * ConfigEntries.IMMORTAL_CHANCE.value() && !$this.getBlockState(pos.below()).is(Blocks.LIGHTNING_ROD);
+                boolean canSpawn = $this.getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING) && $this.random.nextDouble() < difficulty.getEffectiveDifficulty() * ConfigEntries.IMMORTAL_CHANCE.value() && !$this.getBlockState(pos.below()).is(Blocks.LIGHTNING_ROD);
                 if (canSpawn) {
                     Immortal immortal = RCEntityTypes.IMMORTAL.get().create($this);
                     immortal.setPos(pos.getX(), pos.getY(), pos.getZ());

--- a/fabric/src/main/java/com/github/teamfusion/platform/config/fabric/ConfigImpl.java
+++ b/fabric/src/main/java/com/github/teamfusion/platform/config/fabric/ConfigImpl.java
@@ -44,6 +44,6 @@ public class ConfigImpl implements ConfigData {
         public int dead_beard_weight = ConfigEntries.DEAD_BEARD_WEIGHT.value();
 
         @Comment("determines the chance of spawning for Immortals")
-        public float immortal_chance = ConfigEntries.IMMORTAL_CHANCE.value();
+        public double immortal_chance = ConfigEntries.IMMORTAL_CHANCE.value();
     }
 }


### PR DESCRIPTION
This fixes #8 and #18.  
Forge doesn't load a `Float` from a TOML file, it loads a `double`, realizes it can't be assigned to a `Float` and says it needs to be corrected, which means it writes the default value back to the file, only for it to be interpreted as a `double` the next time it is read from the file again. This fixes that by just making the field into a `Double`.