### PR TITLE
Fixed ResourceLocationException crash

### DIFF
--- a/common/src/main/java/com/github/teamfusion/rottencreatures/client/renderer/entity/layers/MummyArmorLayer.java
+++ b/common/src/main/java/com/github/teamfusion/rottencreatures/client/renderer/entity/layers/MummyArmorLayer.java
@@ -3,6 +3,7 @@ package com.github.teamfusion.rottencreatures.client.renderer.entity.layers;
 import com.google.common.collect.Maps;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.ResourceLocationException;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
@@ -95,8 +96,11 @@ public class MummyArmorLayer<T extends LivingEntity, M extends HumanoidModel<T>,
     }
 
     private void renderModel(PoseStack matrices, MultiBufferSource source, int light, ArmorItem item, boolean hasFoil, A model, boolean useInnerModel, float red, float green, float blue, @Nullable String overlay) {
-        VertexConsumer vertices = ItemRenderer.getArmorFoilBuffer(source, RenderType.armorCutoutNoCull(this.getArmorLocation(item, useInnerModel, overlay)), false, hasFoil);
-        model.renderToBuffer(matrices, vertices, light, OverlayTexture.NO_OVERLAY, red, green, blue, 1.0F);
+        ResourceLocation armor_location = this.getArmorLocation(item, useInnerModel, overlay);
+        if (armor_location != null) {
+            VertexConsumer vertices = ItemRenderer.getArmorFoilBuffer(source, RenderType.armorCutoutNoCull(armor_location), false, hasFoil);
+            model.renderToBuffer(matrices, vertices, light, OverlayTexture.NO_OVERLAY, red, green, blue, 1.0F);
+        }
     }
 
     private A getArmorModel(EquipmentSlot slot) {
@@ -107,8 +111,13 @@ public class MummyArmorLayer<T extends LivingEntity, M extends HumanoidModel<T>,
         return slot == EquipmentSlot.LEGS;
     }
 
+    @Nullable
     private ResourceLocation getArmorLocation(ArmorItem armor, boolean legs, @Nullable String overlay) {
         String location = "textures/models/armor/" + armor.getMaterial().getName() + "_layer_" + (legs ? 2 : 1) + (overlay == null ? "" : "_" + overlay) + ".png";
-        return ARMOR_LOCATION_CACHE.computeIfAbsent(location, ResourceLocation::new);
+        try {
+            return ARMOR_LOCATION_CACHE.computeIfAbsent(location, ResourceLocation::new);
+        } catch (ResourceLocationException e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
The mod makes an assumption about the file structure of armor texture files. Not all mods (in my case, environmentals) follow that convention. When this assumption fails, the game crashes. I modified the code so that if it can't get the armor textures loaded properly, it just skips the rendering of it. The damage reduction and stuff of the armor is still there, the armor just isn't visible. Seemed like the best trade off, at least without a big rewrite of that part of the system, which I don't know enough about this codebase to do.