### PR TITLE
Try to fix client crash related to Mummy

### DIFF
--- a/common/src/main/java/com/github/teamfusion/rottencreatures/client/renderer/entity/layers/MummyArmorLayer.java
+++ b/common/src/main/java/com/github/teamfusion/rottencreatures/client/renderer/entity/layers/MummyArmorLayer.java
@@ -108,7 +108,13 @@ public class MummyArmorLayer<T extends LivingEntity, M extends HumanoidModel<T>,
     }
 
     private ResourceLocation getArmorLocation(ArmorItem armor, boolean legs, @Nullable String overlay) {
-        String location = "textures/models/armor/" + armor.getMaterial().getName() + "_layer_" + (legs ? 2 : 1) + (overlay == null ? "" : "_" + overlay) + ".png";
-        return ARMOR_LOCATION_CACHE.computeIfAbsent(location, ResourceLocation::new);
+        String s1 = String.format(Locale.ROOT, "%s:textures/models/armor/%s_layer_%d%s.png", "minecraft", armor.getMaterial().getName(), legs ? 2 : 1, overlay == null ? "" : String.format(Locale.ROOT, "_%s", overlay));
+        ResourceLocation resourcelocation = (ResourceLocation)ARMOR_LOCATION_CACHE.get(s1);
+        if (resourcelocation == null) {
+            resourcelocation = new ResourceLocation(s1);
+            ARMOR_LOCATION_CACHE.put(s1, resourcelocation);
+        }
+
+        return resourcelocation;
     }
 }


### PR DESCRIPTION
I have no idea what I am doing. I only copy some code from method HumanoidArmorLayer#getArmorResource. But it actually fix the problem. I tested it in my server, teleport to the position where players crash, moded armor can render correctly.
![5cc235eccb19ecd33a0cb426a258cf4a](https://github.com/teamfusion/rottencreatures/assets/77628540/1e52b846-6d12-44b0-8d6f-a66ed7702feb)
